### PR TITLE
  feat: 인증 백엔드 기본 골격 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -39,6 +40,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/swproject/config/SecurityConfig.java
+++ b/src/main/java/com/example/swproject/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.example.swproject.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable()) // CSRF protection disable for now
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers("/api/users/signup", "/api/users/login").permitAll() // Permit all for signup and login
+                .anyRequest().authenticated() // All other requests need authentication
+            );
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/swproject/controller/UserController.java
+++ b/src/main/java/com/example/swproject/controller/UserController.java
@@ -1,0 +1,35 @@
+package com.example.swproject.controller;
+
+import com.example.swproject.dto.UserLoginDTO;
+import com.example.swproject.dto.UserSignupDTO;
+import com.example.swproject.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody UserSignupDTO userSignupDTO) {
+        userService.signup(userSignupDTO);
+        return ResponseEntity.ok("User registered successfully");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody UserLoginDTO userLoginDTO) {
+        String token = userService.login(userLoginDTO);
+        return ResponseEntity.ok(token);
+    }
+}

--- a/src/main/java/com/example/swproject/domain/Badge.java
+++ b/src/main/java/com/example/swproject/domain/Badge.java
@@ -1,0 +1,31 @@
+package com.example.swproject.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "badges")
+public class Badge {
+  @Id
+  @Column(name = "badges_id", nullable = false)
+  private Long id;
+
+  @Size(max = 255)
+  @NotNull
+  @Column(name = "badge_name", nullable = false)
+  private String badgeName;
+
+  @Size(max = 255)
+  @NotNull
+  @Column(name = "badge_image_url", nullable = false)
+  private String badgeImageUrl;
+
+}

--- a/src/main/java/com/example/swproject/domain/Place.java
+++ b/src/main/java/com/example/swproject/domain/Place.java
@@ -1,0 +1,64 @@
+package com.example.swproject.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "places")
+public class Place {
+  @Id
+  @Column(name = "places_id", nullable = false)
+  private Long id;
+
+  @Size(max = 255)
+  @NotNull
+  @Column(name = "name", nullable = false)
+  private String name;
+
+  @Size(max = 255)
+  @NotNull
+  @Column(name = "address", nullable = false)
+  private String address;
+
+  @Size(max = 30)
+  @Column(name = "phone", length = 30)
+  private String phone;
+
+  @Size(max = 60)
+  @NotNull
+  @Column(name = "time", nullable = false, length = 60)
+  private String time;
+
+  @Size(max = 255)
+  @NotNull
+  @Column(name = "comment", nullable = false)
+  private String comment;
+
+  @Size(max = 20)
+  @NotNull
+  @Column(name = "category", nullable = false, length = 20)
+  private String category;
+
+  @NotNull
+  @Column(name = "menu", nullable = false)
+  @JdbcTypeCode(SqlTypes.JSON)
+  private Map<String, Object> menu;
+
+  @Size(max = 255)
+  @NotNull
+  @Column(name = "place_image_url", nullable = false)
+  private String placeImageUrl;
+
+}

--- a/src/main/java/com/example/swproject/domain/Review.java
+++ b/src/main/java/com/example/swproject/domain/Review.java
@@ -1,0 +1,41 @@
+package com.example.swproject.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "reviews")
+public class Review {
+  @Id
+  @Column(name = "reviews_id", nullable = false)
+  private Long id;
+
+  @NotNull
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "users_id", nullable = false)
+  private User users;
+
+  @NotNull
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "places_id", nullable = false)
+  private Place places;
+
+  @Size(max = 500)
+  @NotNull
+  @Column(name = "content", nullable = false, length = 500)
+  private String content;
+
+  @NotNull
+  @Column(name = "grade", nullable = false)
+  private Integer grade;
+
+  @Size(max = 255)
+  @Column(name = "visited_image_url")
+  private String visitedImageUrl;
+
+}

--- a/src/main/java/com/example/swproject/domain/User.java
+++ b/src/main/java/com/example/swproject/domain/User.java
@@ -1,0 +1,58 @@
+package com.example.swproject.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "users")
+public class User {
+  @Id
+  @Column(name = "users_id", nullable = false)
+  private Long id;
+
+  @Size(max = 225)
+  @NotNull
+  @Column(name = "login_id", nullable = false, length = 225)
+  private String loginId;
+
+  @Size(max = 225)
+  @NotNull
+  @Column(name = "login_pw", nullable = false, length = 225)
+  private String loginPw;
+
+  @Size(max = 30)
+  @NotNull
+  @Column(name = "email", nullable = false, length = 30)
+  private String email;
+
+  @Size(max = 30)
+  @NotNull
+  @Column(name = "country", nullable = false, length = 30)
+  private String country;
+
+  @Size(max = 30)
+  @Column(name = "religion", length = 30)
+  private String religion;
+
+  @Size(max = 30)
+  @NotNull
+  @Column(name = "phone", nullable = false, length = 30)
+  private String phone;
+
+  @Size(max = 30)
+  @NotNull
+  @Column(name = "job", nullable = false, length = 30)
+  private String job;
+
+  @Column(name = "age", columnDefinition = "int UNSIGNED not null")
+  private Long age;
+
+}

--- a/src/main/java/com/example/swproject/domain/User.java
+++ b/src/main/java/com/example/swproject/domain/User.java
@@ -2,6 +2,8 @@ package com.example.swproject.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -15,6 +17,7 @@ import lombok.Setter;
 @Table(name = "users")
 public class User {
   @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY) // 자동 아이디 생성을 위해 한줄 추가함 나중에 삭제 해도 됨
   @Column(name = "users_id", nullable = false)
   private Long id;
 

--- a/src/main/java/com/example/swproject/domain/UsersBadge.java
+++ b/src/main/java/com/example/swproject/domain/UsersBadge.java
@@ -1,0 +1,33 @@
+package com.example.swproject.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "users_badges")
+public class UsersBadge {
+  @Id
+  @Column(name = "users_badge_id", nullable = false)
+  private Long id;
+
+  @NotNull
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "users_id", nullable = false)
+  private User users;
+
+  @NotNull
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "badges_id", nullable = false)
+  private Badge badges;
+
+  @NotNull
+  @Column(name = "date_time", nullable = false)
+  private Instant dateTime;
+
+}

--- a/src/main/java/com/example/swproject/dto/UserLoginDTO.java
+++ b/src/main/java/com/example/swproject/dto/UserLoginDTO.java
@@ -1,0 +1,25 @@
+package com.example.swproject.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.example.swproject.domain.User}
+ */
+
+@Value
+public class UserLoginDTO implements Serializable {
+  @NotNull
+  @Size(max = 225)
+  @NotEmpty
+  String loginId;
+
+  @NotNull
+  @Size(max = 225)
+  @NotEmpty
+  String loginPw;
+}

--- a/src/main/java/com/example/swproject/dto/UserSignupDTO.java
+++ b/src/main/java/com/example/swproject/dto/UserSignupDTO.java
@@ -1,0 +1,45 @@
+package com.example.swproject.dto;
+
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.example.swproject.domain.User}
+ */
+@Value
+public class UserSignupDTO implements Serializable {
+  @NotNull
+  @Size(max = 225)
+  String loginId;
+
+  @NotNull
+  @Size(max = 225)
+  String loginPw;
+
+  @NotNull
+  @Size(max = 30)
+  String email;
+
+  @NotNull
+  @Size(max = 30)
+  String country;
+
+  @Size(max = 30)
+  String religion;
+
+  @NotNull
+  @Size(max = 30)
+  String phone;
+
+  @NotNull
+  @Size(max = 30)
+  String job;
+
+  @NotNull
+  @Digits(integer = 3, fraction = 0)
+  Long age;
+}

--- a/src/main/java/com/example/swproject/repository/UserRepository.java
+++ b/src/main/java/com/example/swproject/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.example.swproject.repository;
+
+import com.example.swproject.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByLoginId(String loginId);
+}

--- a/src/main/java/com/example/swproject/service/UserService.java
+++ b/src/main/java/com/example/swproject/service/UserService.java
@@ -1,0 +1,48 @@
+package com.example.swproject.service;
+
+import com.example.swproject.domain.User;
+import com.example.swproject.dto.UserLoginDTO;
+import com.example.swproject.dto.UserSignupDTO;
+import com.example.swproject.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signup(UserSignupDTO userSignupDTO) {
+        if (userRepository.findByLoginId(userSignupDTO.getLoginId()).isPresent()) {
+            throw new IllegalStateException("이미 존재하는 아이디입니다.");
+        }
+
+        User user = new User();
+        user.setLoginId(userSignupDTO.getLoginId());
+        user.setLoginPw(passwordEncoder.encode(userSignupDTO.getLoginPw()));
+        user.setEmail(userSignupDTO.getEmail());
+        user.setCountry(userSignupDTO.getCountry());
+        user.setReligion(userSignupDTO.getReligion());
+        user.setPhone(userSignupDTO.getPhone());
+        user.setJob(userSignupDTO.getJob());
+        user.setAge(userSignupDTO.getAge());
+
+        userRepository.save(user);
+    }
+
+    public String login(UserLoginDTO userLoginDTO) {
+        User user = userRepository.findByLoginId(userLoginDTO.getLoginId())
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 아이디 입니다."));
+
+        if (!passwordEncoder.matches(userLoginDTO.getLoginPw(), user.getLoginPw())) {
+            throw new IllegalArgumentException("잘못된 비밀번호입니다.");
+        }
+
+        return "dummy-jwt-token";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=swproject
+
+spring.datasource.url=jdbc:mysql://localhost:3306/testdb?useSSL=false&serverTimezone=UTC
+spring.datasource.username=user
+spring.datasource.password=Dlxorals9809!
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA ?? (????)
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+# Override main datasource for tests to use an in-memory H2 database
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
  feat: 인증 백엔드 기본 골격 구현

  - build.gradle: spring-boot-starter-security 의존성을 추가하여 보안 기능 활성화
  - SecurityConfig:
      - PasswordEncoder(BCrypt)를 Bean으로 등록하여 비밀번호 암호화 기능 제공
      - /api/users/signup, /api/users/login 엔드포인트에 대한 접근 허용 설정
  - User (Domain):
      - @GeneratedValue(strategy = GenerationType.IDENTITY)를 적용하여 DB에서 User ID가 자동 생성되도록 수정
  - UserRepository (Repository):
      - User 엔티티의 CRUD 및 findByLoginId 쿼리 메소드 제공
  - UserService (Service):
      - signup: 아이디 중복 검사 및 PasswordEncoder를 이용한 비밀번호 암호화 후 사용자 저장
      - login: PasswordEncoder를 이용한 비밀번호 일치 여부 검증 및 임시 토큰 반환