### PR TITLE
  feat: 인증 백엔드 기본 골격 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -39,6 +40,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/swproject/config/SecurityConfig.java
+++ b/src/main/java/com/example/swproject/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.example.swproject.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable()) // CSRF protection disable for now
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers("/api/users/signup", "/api/users/login").permitAll() // Permit all for signup and login
+                .anyRequest().authenticated() // All other requests need authentication
+            );
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/swproject/domain/User.java
+++ b/src/main/java/com/example/swproject/domain/User.java
@@ -2,6 +2,8 @@ package com.example.swproject.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -15,6 +17,7 @@ import lombok.Setter;
 @Table(name = "users")
 public class User {
   @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY) // 자동 아이디 생성을 위해 한줄 추가함 나중에 삭제 해도 됨
   @Column(name = "users_id", nullable = false)
   private Long id;
 

--- a/src/main/java/com/example/swproject/repository/UserRepository.java
+++ b/src/main/java/com/example/swproject/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.example.swproject.repository;
+
+import com.example.swproject.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByLoginId(String loginId);
+}

--- a/src/main/java/com/example/swproject/service/UserService.java
+++ b/src/main/java/com/example/swproject/service/UserService.java
@@ -1,0 +1,48 @@
+package com.example.swproject.service;
+
+import com.example.swproject.domain.User;
+import com.example.swproject.dto.UserLoginDTO;
+import com.example.swproject.dto.UserSignupDTO;
+import com.example.swproject.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signup(UserSignupDTO userSignupDTO) {
+        if (userRepository.findByLoginId(userSignupDTO.getLoginId()).isPresent()) {
+            throw new IllegalStateException("이미 존재하는 아이디입니다.");
+        }
+
+        User user = new User();
+        user.setLoginId(userSignupDTO.getLoginId());
+        user.setLoginPw(passwordEncoder.encode(userSignupDTO.getLoginPw()));
+        user.setEmail(userSignupDTO.getEmail());
+        user.setCountry(userSignupDTO.getCountry());
+        user.setReligion(userSignupDTO.getReligion());
+        user.setPhone(userSignupDTO.getPhone());
+        user.setJob(userSignupDTO.getJob());
+        user.setAge(userSignupDTO.getAge());
+
+        userRepository.save(user);
+    }
+
+    public String login(UserLoginDTO userLoginDTO) {
+        User user = userRepository.findByLoginId(userLoginDTO.getLoginId())
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 아이디 입니다."));
+
+        if (!passwordEncoder.matches(userLoginDTO.getLoginPw(), user.getLoginPw())) {
+            throw new IllegalArgumentException("잘못된 비밀번호입니다.");
+        }
+
+        return "dummy-jwt-token";
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+# Override main datasource for tests to use an in-memory H2 database
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
  - build.gradle: spring-boot-starter-security 의존성을 추가하여 보안 기능 활성화
  - SecurityConfig:
      - PasswordEncoder(BCrypt)를 Bean으로 등록하여 비밀번호 암호화 기능 제공
      - /api/users/signup, /api/users/login 엔드포인트에 대한 접근 허용 설정
  - User (Domain): - @GeneratedValue(strategy = GenerationType.IDENTITY)를 적용하여 DB에서 User ID가 자동 생성되도록 수정
  - UserRepository (Repository):
      - User 엔티티의 CRUD 및 findByLoginId 쿼리 메소드 제공
  - UserService : - signup: 아이디 중복 검사 및 PasswordEncoder를 이용한 비밀번호 암호화 후 사용자 저장 - login: PasswordEncoder를 이용한 비밀번호 일치 여부 검증 및 임시 토큰 반환